### PR TITLE
#48 upgrade zookeeper version to 3.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
 ### Changed
 - *[#44](https://github.com/idealista/zookeeper_role/issues/44) Upgrade version to 3.4.14* @eskabetxe
+- *[#48](https://github.com/idealista/zookeeper_role/issues/48) Upgrade version to 3.5.5* @eskabetxe
 
 
 ## [1.5.0](https://github.com/idealista/zookeeper_role/tree/1.5.0) (2019-02-22)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 ## General
-zookeeper_version: 3.4.13
+
+zookeeper_version: 3.5.5
 
 ## Service options
 
@@ -36,6 +37,9 @@ zookeeper_tick_time: "{{ tick_time }}"
 
 zookeeper_autopurge_purgeInterval: 0
 zookeeper_autopurge_snapRetainCount: 10
+
+# 4lw commands (stat, ruok, isro, ...)
+zookeeper_4lw_commands_whitelist: stat
 
 # Java options
 zookeeper_jmx_enabled: true

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -27,3 +27,5 @@ server.{{loop.index}}={{server}}:2888:3888
 {{config.key}}={{config.value}}
 {% endfor %}
 {% endif %}
+
+4lw.commands.whitelist={{ zookeeper_4lw_commands_whitelist }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,5 +3,5 @@
 zookeeper_required_libs:
   - unzip
 
-zookeeper_url: "http://apache.rediris.es/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz"
+zookeeper_url: "http://apache.rediris.es/zookeeper/zookeeper-{{zookeeper_version}}/apache-zookeeper-{{zookeeper_version}}-bin.tar.gz"
 zookeeper_main_file: org.apache.zookeeper.server.quorum.QuorumPeerMain


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change

bump zookeeper version to 3.5.5


### Benefits

last statble version

### Possible Drawbacks

unknown

### Applicable Issues
#48 
