### PR TITLE
Issue 52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
+### Changed
+- *[#52](https://github.com/idealista/zookeeper_role/issues/52) Added comment filter to Ansible managed comments in templates @angeldelrio
 
 ## [1.5.1](https://github.com/idealista/zookeeper_role/tree/1.5.1) (2019-07-04)
 ### Changed

--- a/templates/log4j.properties.j2
+++ b/templates/log4j.properties.j2
@@ -1,4 +1,5 @@
-# {{ansible_managed}}
+{{ ansible_managed | comment }}
+
 # Define some default values that can be overridden by system properties
 zookeeper.root.logger=INFO, ROLLINGFILE
 zookeeper.console.threshold=INFO

--- a/templates/zookeeper.service.j2
+++ b/templates/zookeeper.service.j2
@@ -1,4 +1,4 @@
-# {{ansible_managed}}
+{{ ansible_managed | comment }}
 
 [Unit]
 Description=ZooKeeper


### PR DESCRIPTION
### Description of the Change

Fixed Ansible managed comment in some templates that are breaking them when multiline comment is being printed


### Benefits

Multiline comments are printed as expected

### Possible Drawbacks

None

### Applicable Issues

 #52 
