### PR TITLE
Fixed template ansible managed comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
-python: 2.7.15
+python: "2.7.15"
 sudo: required
+
 services:
 - docker
 install:
@@ -12,15 +13,19 @@ env:
   - secure: XlU2gbVAKXxeBq0ytMd9ayYAeh9aOjKmanDnX5TrsBzOxFpLH5fBZIbfo40eYyyIWt3kkZ4RzuDBSq7t2AJYWCnsYc/7qCDL1X0wwlKsdiehxoX7XO7DcnAW+OKD93nHkshjt0LyjqdRfsvfoe7TKn9h8cSbxP4rDV+bfHKnng4FzZFppjmJeilbUHwj3MjB4aENeP5qqB7hmhnAImh2xlUT0f9NjmingYgaeP1s+MYuJDzwIUUHfwqwVnR7TA4/UtuE+XTtGyYQ4Tu/u5X7gRw9iT3f3f0+vlvmOzD+EpqGZELl9vGlpkTnD9g4TkaDbaCUb/qIbhZKRspPBdIQxq1mmgz8P5XAnOLH4CNAyNgQWJkrKqB1CYpUBKvDEWUJGHAIFoiyENTwMDMpg+75HCBAcz3RzDcEuzfUKZj2cyU9/ed+WwftjFJUklu8O9yjwEOsO4IeontPiMUa++Pf4FnJqPtUgWv5fja8Alqjdzgv/X4l0w59gXN+dTPbKIigVSi6t7oZQyH4WquHr+NTVhc/JuvzVlQ9Gr+t/0YGDX1x+jYErs/mTdNvacYzh+bCP8sN6YgKK7FgJ8gCrzmlO5CelZ5NBmWVkxlx8v8QFN0qDiqxsg8Wjd1RhyflZ4YFSo0DOhoxaodOn9CvmMQuIA1zft5Bz4DpeNFazAiQ5zU=
   - secure: QAR4xX2pqzgJkSNye8XmYjcgDzS2UJfEq9jxdSl5Eav5lJy5aqqF8fycv6s6CeXvIqoRV7z9s06io6IWZ096XrKPncDnv8syzAKFSxFLiSiH7bUqvrJY8B/UqYmEkO4t/4AhsB58Fbhi2v3dc+a3NbtAiIBqU+hcD72MuwvykuyG7q/74+/MOVZor5bk2U/FtJZRoGMVIYRdjzeui4N8e6AeyJuCCJ0bJ+/FoS9m1X7dcpM+otrY7MrqQOs0e/7B+mE8ez6+NhcuUh3S21vZkGMfxKLRJoYH07WRheXpw8qAINQeeo0TE2I12H3I/Oyb8fEatc5cEyZ1dLNn4X5LCl+tEAWBWY/BKmHiko98YE9bOP2Jw4y6ArPc/ZhuYqMTiUgtGZZ1uz9MSaKzRncoMB6+eO29oOFwNLgVFnzvgC1ZhWUnQQUvOOD4EfhsEqUJ67sMuGjNHB2os2ppanc7myJE/xlTZxKQXE4OE8HJ0HxdEEVyZl13M0aos00MQTMgFaaxmX1GIPEV5oFW8/E3yZoKUcC2Urihn/RM/2aVhsIcqXPeQ7m8l/jODfcP4U04IaoMgNMPmUFlk4Ly2W+ugSXk6xSlu39VQeTRJznFuRKVyU1QlNdiIGvbKsLalMj5LyxlMOVGpqRwtngHmT80+puu01Cu4KnuJmujV0PSp9k=
   - secure: j7g0vouk54s0Z1fGwuF6iTk0ZwIzdLGB5isT4dtYYpyI+N+jdu1OrXX/gazZujsw7eNl5dICj0n0mbfPV6lrxegJfB4xdm6uvF0fODj5dbg8kdywsI8lxpd7nbAyWAUClAXw8ij+5ItIlIkHezge846olneU8JI31RxijDo1SvMdkd1PWlrbW0EBv7iAAA2Ex7HIM9MxBYFZKpxwFFcjawiJFyNLunuhPGsyHdMc51uLfq/eIR0hRaZxTqyR2nd9r9dG/4xlaxAuVycD4tOyp4poIri+vkOS5Ff3dtUCv2KWIbiNAG8fcEXjwkmHJrwYTwv9eEtmLZwWgTAVFOMV2DEsR+y6EeZU3g8UT8TZc6pbylvhyihgLWp6UfVJjyqzYFXYhu5JO+QOUIrv/I3BnKWmEt8xnwIXhydNQJPnhnGDsde+UoUk5ZMUhBimOAxic2AonIhMHJk6w2nWzZIwHeBjsIAfsf89zy37TIgL2KrqTztOHZ8B6OgB9TdF756R2zBa8wsUdxav3XluxMLy74jTzHQdZWKljVLyeSMdjwO6hm7LVWvYp49e8IWhMcWO5rdTrhsYkXClTRZdI8BitoHGAiN/0eEIH2uO7lmXQrl1SqYtMbtYrO/7z+Jldt61bLvmn9mVoweK0YQYZMxSaY8LCnOBNiksIryGrNeJ2Zk=
-
+  matrix:
+    - ZOOKEEPER_VERSION=3.4.14
+    - ZOOKEEPER_VERSION=3.5.5
 script:
-- pipenv run molecule test
+  - pipenv run molecule test
+
 notifications:
-  webhooks: https://galaxy.ansible.com/api/v1/notifications/
+  webhooks:
+    - https://galaxy.ansible.com/api/v1/notifications/
+
 deploy:
   provider: script
-  script:
-  - ANSIBLE_ROLES_PATH=../ pipenv run ansible-playbook dockerhub/deploy.yml --extra-vars "docker_hub_email=${DOCKER_EMAIL} docker_hub_username=${DOCKER_USERNAME} docker_hub_password=${DOCKER_PASSWORD}"
+  script: ANSIBLE_ROLES_PATH=../ pipenv run ansible-playbook dockerhub/deploy.yml --extra-vars "docker_hub_email=${DOCKER_EMAIL} docker_hub_username=${DOCKER_USERNAME} docker_hub_password=${DOCKER_PASSWORD}"
   on:
     branch: master
     tags: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
+### Changed
+- *[#52](https://github.com/idealista/zookeeper_role/issues/52) Added comment filter to template Ansible managed comments * @angeldelrio
 
 ## [1.5.1](https://github.com/idealista/zookeeper_role/tree/1.5.1) (2019-07-04)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,16 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
+### Added
+- *Added whitelist of commands for check stat of current zookeeper running* @adrian-arapiles
+- *Added matrix to travis for test version <3.5.5 and >=3.5.5* @adrian-arapiles
+
 ### Changed
-- *[#52](https://github.com/idealista/zookeeper_role/issues/52) Added comment filter to template Ansible managed comments * @angeldelrio
+- *Use idealista/jdk:8u222-stretch-openjdk-headless Docker Image in Molecule Tests* @dortegau
+- *[#52](https://github.com/idealista/zookeeper_role/issues/52) Added comment filter to template Ansible managed comments* @angeldelrio
+- *Avoid privileged true on docker molecule test* @adrian-arapiles
+- *[#48](https://github.com/idealista/zookeeper_role/issues/48) Update url to download zookeeper for use 3.5.5 version* @adrian-arapiles
+- *Upgrade ansible version to 2.8.2 for security vulnerabilities* @adrian-arapiles
 
 ## [1.5.1](https://github.com/idealista/zookeeper_role/tree/1.5.1) (2019-07-04)
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
+
+## [1.5.1](https://github.com/idealista/zookeeper_role/tree/1.5.1) (2019-07-04)
 ### Changed
 - *[#46](https://github.com/idealista/zookeeper_role/issues/46) Upgrade pipenv versions* @eskabetxe
 - *[#44](https://github.com/idealista/zookeeper_role/issues/44) Upgrade version to 3.4.14* @eskabetxe

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 This Ansible role installs an Apache ZooKeeper service in a Debian environment.
 
 - [Getting Started](#getting-started)
-	- [Prerequisities](#prerequisities)
+	- [Prerequisites](#prerequisities)
 	- [Installing](#installing)
 - [Usage](#usage)
 - [Testing](#testing)
@@ -23,11 +23,11 @@ This Ansible role installs an Apache ZooKeeper service in a Debian environment.
 
 These instructions will get you a copy of the role for your Ansible Playbook. Once launched, it will install an Apache ZooKeeper server.
 
-### Prerequisities
+### Prerequisites
 
 #### To execute this role:
 
-Ansible 2.8.1 version installed.
+Ansible 2.8.2 version installed.
 
 :warning: Inventory destination should be a Debian environment. Notice that you will need to [install Java](https://github.com/idealista/java_role) in that environment after execute this role.
 
@@ -47,7 +47,7 @@ Create or add to your roles dependency file (e.g requirements.yml):
 
 ```
 - src: idealista.zookeeper_role
-  version: 1.5.0
+  version: 1.5.1
   name: zookeeper
 ```
 
@@ -91,7 +91,7 @@ $ pipenv run molecule test
 
 ## Built With
 
-![Ansible](https://img.shields.io/badge/ansible-2.8.1-green.svg)
+![Ansible](https://img.shields.io/badge/ansible-2.8.2-green.svg)
 
 ## Versioning
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 ## General
-zookeeper_version: 3.4.14
+zookeeper_version: 3.5.5
 
 ## Service options
 
@@ -58,6 +58,8 @@ zookeeper_env: {}
 zookeeper_force_myid: true
 
 zookeeper_force_reinstall: false
+
+zookeeper_4lw_commands_whitelist: stat
 
 #
 # You can add more zookeper config options using zookeeper_config_map

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,8 +6,14 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get upgrade -y && apt-get install -y python sudo systemd systemd-sysv bash ca-certificates && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum update -y && yum install -y python sudo yum-plugin-ovl bash && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper update -y && zypper install -y python sudo bash python-xml && zypper clean -a; \
-    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; fi
+# install minimal packages for debian slim images
+RUN apt-get update && \
+    apt-get install -y python sudo bash ca-certificates iproute systemd systemd-sysv python-pip && \
+    apt-get clean
+
+# https://github.com/moby/moby/issues/28614#issuecomment-310581026
+STOPSIGNAL SIGRTMIN+3
+RUN systemctl set-default multi-user.target
+
+# TIP 4
+# RUN mkdir -p /usr/share/man/man1

--- a/molecule/default/create.yml
+++ b/molecule/default/create.yml
@@ -54,7 +54,11 @@
         published_ports: "{{ item.published_ports | default(omit) }}"
         ulimits: "{{ item.ulimits | default(omit) }}"
         networks: "{{ item.networks | default(omit) }}"
+        purge_networks: "{{ item.purge_networks | default(omit) }}"
         dns_servers: "{{ item.dns_servers | default(omit) }}"
+        stop_signal: "{{ item.stop_signal | default(omit) }}"
+        tmpfs: "{{ item.tmpfs | default(omit) }}"
+        devices: "{{ item.devices | default(omit) }}"
       register: server
       with_items: "{{ molecule_yml.platforms }}"
       async: 7200

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,11 +13,19 @@ platforms:
     groups:
       - zookeeper
     image: idealista/jdk:8u181-stretch-openjdk-headless
-    privileged: true
+    privileged: false
     capabilities:
       - SYS_ADMIN
     volumes:
       - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/fuse/connections:/sys/fs/fuse/connections:ro'
+      - '/dev/hugepages:/dev/hugepages'
+    tmpfs:
+      - '/tmp'
+      - '/run'
+      - '/run/lock'
+    devices:
+      - '/dev/fuse:/dev/fuse'
     networks:
       - name: zookeeper-network
         links:
@@ -29,11 +37,19 @@ platforms:
     groups:
       - zookeeper
     image: idealista/jdk:8u181-stretch-openjdk-headless
-    privileged: true
+    privileged: false
     capabilities:
       - SYS_ADMIN
     volumes:
       - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/fuse/connections:/sys/fs/fuse/connections:ro'
+      - '/dev/hugepages:/dev/hugepages'
+    tmpfs:
+      - '/tmp'
+      - '/run'
+      - '/run/lock'
+    devices:
+      - '/dev/fuse:/dev/fuse'
     networks:
       - name: zookeeper-network
         links:
@@ -45,11 +61,19 @@ platforms:
     groups:
       - zookeeper
     image: idealista/jdk:8u181-stretch-openjdk-headless
-    privileged: true
+    privileged: false
     capabilities:
       - SYS_ADMIN
     volumes:
       - '/sys/fs/cgroup:/sys/fs/cgroup:ro'
+      - '/sys/fs/fuse/connections:/sys/fs/fuse/connections:ro'
+      - '/dev/hugepages:/dev/hugepages'
+    tmpfs:
+      - '/tmp'
+      - '/run'
+      - '/run/lock'
+    devices:
+      - '/dev/fuse:/dev/fuse'
     networks:
       - name: zookeeper-network
         links:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,7 +12,7 @@ platforms:
   - name: zookeeper1
     groups:
       - zookeeper
-    image: idealista/jdk:8u181-stretch-openjdk-headless
+    image: idealista/jdk:8u222-stretch-openjdk-headless
     privileged: false
     capabilities:
       - SYS_ADMIN
@@ -36,7 +36,7 @@ platforms:
   - name: zookeeper2
     groups:
       - zookeeper
-    image: idealista/jdk:8u181-stretch-openjdk-headless
+    image: idealista/jdk:8u222-stretch-openjdk-headless
     privileged: false
     capabilities:
       - SYS_ADMIN
@@ -60,7 +60,7 @@ platforms:
   - name: zookeeper3
     groups:
       - zookeeper
-    image: idealista/jdk:8u181-stretch-openjdk-headless
+    image: idealista/jdk:8u222-stretch-openjdk-headless
     privileged: false
     capabilities:
       - SYS_ADMIN
@@ -83,6 +83,10 @@ platforms:
 
 provisioner:
   name: ansible
+  inventory:
+    group_vars:
+      zookeeper:
+        zookeeper_version: ${ZOOKEEPER_VERSION:-"3.5.5"}
   lint:
     name: ansible-lint
 scenario:

--- a/templates/log4j.properties.j2
+++ b/templates/log4j.properties.j2
@@ -1,4 +1,5 @@
-# {{ansible_managed}}
+{{ ansible_managed|comment }}
+
 # Define some default values that can be overridden by system properties
 zookeeper.root.logger=INFO, ROLLINGFILE
 zookeeper.console.threshold=INFO

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -27,3 +27,7 @@ server.{{loop.index}}={{server}}:2888:3888
 {{config.key}}={{config.value}}
 {% endfor %}
 {% endif %}
+
+{% if zookeeper_4lw_commands_whitelist is defined %}
+4lw.commands.whitelist={{ zookeeper_4lw_commands_whitelist }}
+{% endif %}

--- a/templates/zookeeper.service.j2
+++ b/templates/zookeeper.service.j2
@@ -1,4 +1,4 @@
-# {{ansible_managed}}
+{{ ansible_managed|comment }}
 
 [Unit]
 Description=ZooKeeper

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
-ansible==2.8.1
+ansible==2.8.2
 molecule==2.20.1
 docker==4.0.2

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,5 +3,11 @@
 zookeeper_required_libs:
   - unzip
 
-zookeeper_url: "http://apache.rediris.es/zookeeper/zookeeper-{{zookeeper_version}}/zookeeper-{{zookeeper_version}}.tar.gz"
+# Define url changes when version is old of 3.5.5
+zookeeper_old_version: "{{ zookeeper_version is version('3.5.5', '<') }}"
+zookeeper_old_package_name: "zookeeper-{{ zookeeper_version }}"
+zookeeper_package_name: "apache-zookeeper-{{ zookeeper_version }}-bin"
+
+zookeeper_url: "https://archive.apache.org/dist/zookeeper/zookeeper-{{ zookeeper_version }}/{{ (zookeeper_old_version) | ternary(zookeeper_old_package_name, zookeeper_package_name) }}.tar.gz"
+
 zookeeper_main_file: org.apache.zookeeper.server.quorum.QuorumPeerMain


### PR DESCRIPTION
### Description of the Change
### Added
- *Added whitelist of commands for check stat of current zookeeper running* @adrian-arapiles
- *Added matrix to travis for test version <3.5.5 and >=3.5.5* @adrian-arapiles
### Changed
Fixed Ansible managed comment in some templates that are breaking them when multiline comment is being printed
- *[#52](https://github.com/idealista/zookeeper_role/issues/52) Added comment filter to template Ansible managed comments* @angeldelrio
- *Avoid privileged true on docker molecule test* @adrian-arapiles
- *[#48](https://github.com/idealista/zookeeper_role/issues/48) Update url to download zookeeper for use 3.5.5 version* @adrian-arapiles
- *Upgrade ansible version to 2.8.2 for security vulnerabilities* @adrian-arapiles
### Benefits

Multiline comments are printed as expected.
Upgrade ansible version to 2.8.2 for security vulnerabilities
Avoid privileged true on docker molecule test
Now can update to latest stable version of zookeeper (current 3.5.5)
### Possible Drawbacks

None

### Applicable Issues

#52 
#48 
