### PR TITLE
Fix dockerhub build image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
 
+### Fixed
+- *[#57](https://github.com/idealista/zookeeper_role/issues/57) Fix dockerhub build image* @adrian-arapiles
 
 ## [2.0.0](https://github.com/idealista/zookeeper_role/tree/2.0.0) (2019-10-10)
 ### Added

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -1,7 +1,7 @@
-FROM idealista/jdk:8u181-stretch-openjdk-headless
+FROM idealista/jdk:8u212-stretch-openjdk-headless
 LABEL maintainer="idealista <labs@idealista.com>"
 
-RUN apt-get update \
+RUN rm -rf /var/lib/apt/lists/* && apt-get update \
     && apt-get install -y sudo systemd systemd-sysv
 
 EXPOSE 2181 2888 3888

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -2,9 +2,8 @@ FROM idealista/jdk:8u212-stretch-openjdk-headless
 LABEL maintainer="idealista <labs@idealista.com>"
 
 RUN rm -rf /var/lib/apt/lists/* && apt-get update \
-    && apt-get install -y sudo systemd systemd-sysv
-
-RUN apt-get autoremove -y && apt-get clean
+    && apt-get install -y sudo systemd systemd-sysv \
+    && apt-get autoremove -y && apt-get clean
 
 EXPOSE 2181 2888 3888
 

--- a/dockerhub/Dockerfile
+++ b/dockerhub/Dockerfile
@@ -4,6 +4,8 @@ LABEL maintainer="idealista <labs@idealista.com>"
 RUN rm -rf /var/lib/apt/lists/* && apt-get update \
     && apt-get install -y sudo systemd systemd-sysv
 
+RUN apt-get autoremove -y && apt-get clean
+
 EXPOSE 2181 2888 3888
 
 CMD ["/sbin/init"]


### PR DESCRIPTION
### Description of the Change

Update image used from java to build zookeeper image to dockerhub.

### Benefits

Build and deploy image to dockerhub.

### Possible Drawbacks

Any.

### Applicable Issues

#57 
