### PR TITLE
Separate text log from zookeeper data log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
 ### Added
-- *Added `zookeeper_data_log_dir` to separate text log paths from Zk data log* @angeldelrio
+- *[#62](https://github.com/idealista/zookeeper_role/issues/62) Added `zookeeper_data_log_dir` to separate text log paths from Zk data log* @angeldelrio
 
 ## [2.0.1](https://github.com/idealista/zookeeper_role/tree/2.0.1) (2019-10-11)
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
+### Added
+- *Added `zookeeper_data_log_dir` to separate text log paths from Zk data log* @angeldelrio
 
 ## [2.0.1](https://github.com/idealista/zookeeper_role/tree/2.0.1) (2019-10-11)
 ### Fixed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ zookeeper_service_state: started
 # Files & Paths
 zookeeper_data_dir: /usr/local/zookeeper
 zookeeper_log_dir: /var/log/zookeeper
+zookeeper_data_log_dir: "{{ zookeeper_log_dir }}"
 zookeeper_install_path: /opt/zookeeper
 zookeeper_conf_dir: "{{ zookeeper_install_path }}/conf"
 

--- a/molecule/default/group_vars/zookeeper.yml
+++ b/molecule/default/group_vars/zookeeper.yml
@@ -14,3 +14,8 @@ zookeeper_hosts:
 zookeeper_config_map:
   - key: traceFile
     value: zoo-trace.log
+
+zookeeper_data_dir: /var/lib/zookeeper/data
+zookeeper_log_dir: /var/log/zookeeper
+zookeeper_install_path: /opt/zookeeper
+zookeeper_conf_dir: "{{ zookeeper_install_path }}/conf"

--- a/templates/zoo.cfg.j2
+++ b/templates/zoo.cfg.j2
@@ -1,6 +1,6 @@
 tickTime={{ zookeeper_tick_time }}
 dataDir={{ zookeeper_data_dir }}
-dataLogDir={{ zookeeper_log_dir }}
+dataLogDir={{ zookeeper_data_log_dir }}
 clientPort={{ zookeeper_client_port }}
 initLimit={{ zookeeper_init_limit }}
 syncLimit={{ zookeeper_sync_limit }}


### PR DESCRIPTION
### Description of the Change
Added new variable `zookeeper_data_log_dir` to be able to specify different paths for text log and Zk data log, by default if not overriden in playbook this new variable will fallback to `zookeeper_log_dir` value to not modify actual behaviour

### Benefits
Specify different paths for text log and for Zk log

### Possible Drawbacks
None

Issue #62 