### PR TITLE
Fixed wrong data log directory ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
+### Fixed
+- *[#65](https://github.com/idealista/zookeeper_role/issues/65) Set `zookeeper_data_log_dir` ownership to `zookeeper_user` * @angeldelrio
+
 ## [2.1.0](https://github.com/idealista/zookeeper_role/tree/2.1.0) (2019-10-22)
 ### Added
 - *[#62](https://github.com/idealista/zookeeper_role/issues/62) Added `zookeeper_data_log_dir` to separate text log paths from Zk data log* @angeldelrio

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,6 +33,7 @@
     - "{{ zookeeper_install_path }}"
     - "{{ zookeeper_conf_dir }}"
     - "{{ zookeeper_data_dir }}"
+    - "{{ zookeeper_data_log_dir }}"
     - "{{ zookeeper_log_dir }}"
 
 - name: ZOOKEEPER | Check ZooKeeper version


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions
* Remember to set **idealista:develop** as base branch;

### Description of the Change
Set ownership of `zookeeper_data_log_dir` path to Zk user


### Benefits
Fixes #65 

### Possible Drawbacks
None

### Applicable Issues
#65 
