### PR TITLE
Add Check zookeepers cluster status

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,3 +20,8 @@
   import_tasks: service.yml
   tags:
     - zookeeper_service
+
+- name: ZOOKEEPER | Check zookeepers cluster status
+  shell: |
+    set -o pipefail && \
+    echo stat | nc 127.0.0.1 2181 | grep Mode | grep -E -w  "leader|follower"


### PR DESCRIPTION
Hello!
Thanks for role!
I have error in inventory or OS when install zookeeper.
But role don`t view error.
If i check by:
```
echo stat | nc 127.0.0.1 2181 | grep Mode | grep -E -w  "leader|follower"
```
Don`t see leader or follower

After add check zookeepers cluster status i get error.
```
TASK [Check zookeepers cluster status] ***********************************************************************************************************************
Tuesday 05 April 2022  20:14:27 +0600 (0:00:02.798)       0:01:24.484 *********
fatal: [clickhouse1]: FAILED! => changed=true
  cmd: echo stat | nc 127.0.0.1 2181 | grep Mode | grep -E -w  "leader|follower"
  delta: '0:00:00.003446'
  end: '2022-04-05 14:14:30.720101'
  msg: non-zero return code
  rc: 1
  start: '2022-04-05 14:14:30.716655'
  stderr: ''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
fatal: [clickhouse2]: FAILED! => changed=true
  cmd: echo stat | nc 127.0.0.1 2181 | grep Mode | grep -E -w  "leader|follower"
  delta: '0:00:00.003242'
  end: '2022-04-05 14:14:30.737254'
  msg: non-zero return code
  rc: 1
  start: '2022-04-05 14:14:30.734012'
  stderr: ''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
fatal: [clickhouse0]: FAILED! => changed=true
  cmd: echo stat | nc 127.0.0.1 2181 | grep Mode | grep -E -w  "leader|follower"
  delta: '0:00:00.003357'
  end: '2022-04-05 14:14:30.876920'
  msg: non-zero return code
  rc: 1
  start: '2022-04-05 14:14:30.873563'
  stderr: ''
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```


Code not pretty. But code may by will refactor.