### PR TITLE
BIG-3231: fix for Debian 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
+## [2.2.1](https://github.com/idealista/zookeeper_role/tree/2.2.1) (2025-09-16)
 ## Added
+- *[#81](https://github.com/idealista/zookeeper_role/pull/81) (2025-09-16)- Move "zookeeper_required_libs" var to defaults.* @smmoreno
 - *[#80](https://github.com/idealista/zookeeper_role/pull/80) (2024-01-17)- Add ".gitattributes" file for linguist detection.* @ygomezsaiz
 
-## [Unreleased](https://github.com/idealista/zookeeper_role/tree/develop)
-## [2.2.0](https://github.com/idealista/zookeeper_role/tree/2.11.0) (2021-12-17)
+## [2.2.0](https://github.com/idealista/zookeeper_role/tree/2.2.0) (2021-12-17)
 ## Added
 - *[#69](https://github.com/idealista/zookeeper_role/issues/69) Support for agent installation.* @jmonterrubio
 ### Fixed

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,11 @@
 ## General
 zookeeper_version: 3.5.6
 
+## Dependencies pre-installation
+zookeeper_required_libs:
+  - unzip
+  - netcat
+
 ## Service options
 
 # Owner

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,4 @@
 ---
-
-zookeeper_required_libs:
-  - unzip
-  - netcat
 # Define url changes when version is old of 3.5.5
 zookeeper_old_version: "{{ zookeeper_version is version('3.5.5', '<') }}"
 zookeeper_old_package_name: "zookeeper-{{ zookeeper_version }}"


### PR DESCRIPTION
It's gonna be a minor release with these changes.

### Description of the Change

In Debian 11, netcat is a transitional package depending on netcat-openbsd, but in Debian 12 is dropped and you need to choose the implementation you want, for example netcat-openbsd
This library is set in the main var *zookeeper_required_libs*. We have moved the var to *defaults* in order to be overwritten in the playbooks 

### Benefits

Support Debian 11 or Debian 12 but in the playbook, even if you need to install more libraries

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
